### PR TITLE
docs: Convert file references to clickable markdown links (CodeRabbit feedback)

### DIFF
--- a/docs/REMEDIATION_SUMMARY.md
+++ b/docs/REMEDIATION_SUMMARY.md
@@ -37,7 +37,7 @@
 
 ## 📋 Deliverables Created
 
-### 1. **Comprehensive Defect Log** (`DEFECT_LOG.md`)
+### 1. **Comprehensive Defect Log** ([defects/DEFECT_LOG.md](defects/DEFECT_LOG.md))
 - Unique defect IDs (DEF-001 through DEF-021)
 - Severity classifications
 - Complete resolution notes

--- a/docs/environment/baseline_training_environment_setup.md
+++ b/docs/environment/baseline_training_environment_setup.md
@@ -722,13 +722,13 @@ python test_environment.py
 ## Supporting Templates
 
 ### ENV_READINESS.md Template
-See: `ENV_READINESS.md` for verification logging template
+See: [ENV_READINESS.md](ENV_READINESS.md) for verification logging template
 
 ### Artifact Header Template
-See: `Artifact_Header_Template.md` for file edit documentation requirements
+See: [Artifact Header Template](../templates/Artifact_Header_Template.md) for file edit documentation requirements
 
 ### Hosts File Template
-See: `Hosts_File_Template.txt` for standardized HX-Infrastructure entries
+See: [Hosts File Template](../templates/Hosts_File_Template.txt) for standardized HX-Infrastructure entries
 
 ---
 

--- a/docs/templates/Artifact_Header_Template.md
+++ b/docs/templates/Artifact_Header_Template.md
@@ -152,7 +152,7 @@ This template integrates with the Do → Verify → Log pattern:
 1. **Before Do:** Complete this template
 2. **During Do:** Follow the documented change plan
 3. **During Verify:** Use the acceptance criteria
-4. **During Log:** Reference this documentation in ENV_READINESS.md
+4. **During Log:** Reference this documentation in [ENV_READINESS.md](../environment/ENV_READINESS.md)
 
 ### File Naming Convention
 


### PR DESCRIPTION
## Repository Cleanup - Closing Obsolete PR

This PR is being closed as part of a comprehensive repository cleanup and branch standardization process. The changes from this PR have been superseded by the Python 3.12 standardization merge that was just completed.

**What happened:**
- ✅ Python 3.12 standardization branch has been merged to main
- ✅ Repository has been cleaned up to maintain only main and test-environment-implementation branches
- ✅ All documentation improvements and link fixes have been incorporated into the main branch
- ✅ Source branch (doc-link-fix) has been deleted as part of cleanup

**Status:** CLOSED - Superseded by Python 3.12 standardization merge